### PR TITLE
DEVOP-1 add dependabot and pr template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Purpose
+
+<!--What is this pull request for?--> 
+
+<!--Linking to the original ticket is a perfectly viable option-->
+
+# Testing
+
+<!--How can my teammates test this code to ensure it does what it's supposed to?--> 
+
+<!--This is usually a set of instructions beginning with running `git pull` and `git checkout <branchname>` and ending with `git checkout main`-->
+
+# Documentation updates
+
+<!--were there any documentation updates? Let's call this out here to make the reviewer think. This can be removed if not applicable.--> 


### PR DESCRIPTION
# Purpose

<!--What is this pull request for?-->

<!--Linking to the original ticket is a perfectly viable option-->

- Enables [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to scan npm for version bumps of installed packages.

- Creates a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to help enforce best practices for code reviews.


# Testing

<!--How can my teammates test this code to ensure it does what it's supposed to?-->

<!--This is usually a set of instructions beginning with running `git pull` and `git checkout <branchname>` and ending with `git checkout main`-->

- dependabot will start opening PRs when new package versions are available.

- pull request template should auto-populate when creating a PR.

# Documentation updates

<!--were there any documentation updates? Let's call this out here to make the reviewer think. This can be removed if not applicable.-->

The pull request template is self-documenting 🙂 